### PR TITLE
add sentry on the backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+SENTRY_URL=https://<>@<>.ingest.sentry.io/<>
+DATABASE_URL=postgres://<>:<>@localhost:5432/anki
+ROCKET_SECRET_KEY=secret
+R2_URL=https://<>.r2.cloudflarestorage.com/<>
+R2_ACCESS_KEY=secret
+R2_SECRET_KEY=secret

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ bb8-postgres = "0.8.1"
 once_cell = "1.17.1"
 dotenvy = "0.15.7"
 thiserror = "1.0.50"
+sentry = "0.31.8"
 
 [dependencies.rocket_auth]
 version = "0.4.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -970,11 +970,15 @@ async fn manage_decks(user: Option<User>) -> Return<content::RawHtml<String>> {
 
 use rocket::data::{Limits, ToByteUnit};
 
+use crate::error::Reporter;
+
 #[rocket::main]
 async fn main() {
     dotenvy::dotenv().expect(
         "Expected .env file in the root directory containing the database connection string",
     );
+    let _reporter = Reporter::new();
+
     let pool = database::establish_connection()
         .await
         .expect("Failed to establish database connection");


### PR DESCRIPTION
Basically copied from a personal project. Plugin implementation here: https://github.com/CravingCrates/AnkiCollab-Plugin/pull/22.

I did not test them yet, partly because I can't get the plugin to start (something about the google APIs). 

You need to create a Sentry account and then add the endpoint in the .env file and in main.py. The R2 stuff from the .env.example file is not relevant yet.